### PR TITLE
Extend token factory bindings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,8 @@ workflows:
   version: 2
   test:
     jobs:
-      - contract_osmo_reflect
+      - contract_token_reflect
+      - contract_tokenfactory
       - package_bindings
       - package_bindings_test
   build:
@@ -26,7 +27,7 @@ workflows:
              ignore: /.*/
 
 jobs:
-  contract_osmo_reflect:
+  contract_token_reflect:
     docker:
       - image: rust:1.64.0
     working_directory: ~/project/contracts/reflect
@@ -38,7 +39,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-osmo-reflect-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-token-reflect-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -51,7 +52,34 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-osmo-reflect-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-token-reflect-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
+
+  contract_tokenfactory:
+    docker:
+      - image: rust:1.64.0
+    working_directory: ~/project/contracts/tokenfactory
+    steps:
+      - checkout:
+          path: ~/project
+      - run:
+          name: Version information
+          command: rustc --version; cargo --version; rustup --version
+      - restore_cache:
+          keys:
+            - cargocache-tokenfactory-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
+      - run:
+          name: Unit Tests
+          environment:
+            RUST_BACKTRACE: 1
+          command: cargo test --locked
+      - run:
+          name: Build and run schema generator
+          command: cargo schema --locked
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target
+          key: cargocache-tokenfactory-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_bindings:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
           key: cargocache-wasm-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Check wasm contracts
-          command: cosmwasm-check --available-capabilities osmosis,iterator,staking,stargate,cosmwasm_1_1 ./target/wasm32-unknown-unknown/release/*.wasm
+          command: cosmwasm-check --available-capabilities token_factory,iterator,staking,stargate,cosmwasm_1_1 ./target/wasm32-unknown-unknown/release/*.wasm
 
   # This job roughly follows the instructions from https://circleci.com/blog/publishing-to-github-releases-via-circleci/
   build_and_upload_contracts:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "token-bindings"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "token-bindings-test"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "token-reflect"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "tokenfactory"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/reflect/Cargo.toml
+++ b/contracts/reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "token-reflect"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Reflect messages to use for test cases - based on cw-mask"
@@ -20,7 +20,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 cosmwasm-schema = "1.1"
 cosmwasm-std = { version = "1.1", features = ["staking", "stargate"] }
 cosmwasm-storage = "1.1"
-token-bindings = { version = "0.7.0", path = "../../packages/bindings" }
+token-bindings = { version = "0.8.0", path = "../../packages/bindings" }
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = "1.0"

--- a/contracts/tokenfactory/Cargo.toml
+++ b/contracts/tokenfactory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokenfactory"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Roman <roman@osmosis.team>"]
 edition = "2018"
 
@@ -44,7 +44,7 @@ cosmwasm-schema = "1.1"
 cosmwasm-std = "1.1"
 cosmwasm-storage = "1.1"
 cw-storage-plus = "0.15"
-token-bindings = { version = "0.7.0", path = "../../packages/bindings" }
+token-bindings = { version = "0.8.0", path = "../../packages/bindings" }
 cw2 = "0.15"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -52,4 +52,4 @@ thiserror = "1.0"
 
 [dev-dependencies]
 cw-multi-test = "0.15"
-token-bindings-test = { version = "0.7.0", path = "../../packages/bindings-test" }
+token-bindings-test = { version = "0.8.0", path = "../../packages/bindings-test" }

--- a/contracts/tokenfactory/src/contract.rs
+++ b/contracts/tokenfactory/src/contract.rs
@@ -259,6 +259,7 @@ mod tests {
                     }
                     SystemResult::Ok(ContractResult::Ok(binary_request))
                 }
+                _ => todo!(),
             });
         mock_dependencies_with_custom_quierier(custom_querier)
     }

--- a/contracts/tokenfactory/src/contract.rs
+++ b/contracts/tokenfactory/src/contract.rs
@@ -63,7 +63,10 @@ pub fn create_denom(subdenom: String) -> Result<Response<TokenFactoryMsg>, Token
         return Err(TokenFactoryError::InvalidSubdenom { subdenom });
     }
 
-    let create_denom_msg = TokenMsg::CreateDenom { subdenom };
+    let create_denom_msg = TokenMsg::CreateDenom {
+        subdenom,
+        metadata: None,
+    };
 
     let res = Response::new()
         .add_attribute("method", "create_denom")
@@ -310,6 +313,7 @@ mod tests {
 
         let expected_message = CosmosMsg::from(TokenMsg::CreateDenom {
             subdenom: String::from(DENOM_NAME),
+            metadata: None,
         });
         let actual_message = res.messages.get(0).unwrap();
         assert_eq!(expected_message, actual_message.msg);

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "token-bindings-test"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Multitest (and other test helpers) support for Osmosis-specific contracts"
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 
 [dependencies]
 itertools = "0.10"
-token-bindings = { version = "0.7.0", path = "../bindings" }
+token-bindings = { version = "0.8.0", path = "../bindings" }
 cosmwasm-std = "1.1"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/packages/bindings-test/src/error.rs
+++ b/packages/bindings-test/src/error.rs
@@ -8,4 +8,13 @@ pub enum ContractError {
 
     #[error("Invalid full denom '{full_denom}'")]
     InvalidFullDenom { full_denom: String },
+
+    #[error("Not admin of token, cannot perfrom action")]
+    NotTokenAdmin,
+
+    #[error("Token denom already exists, cannot create again")]
+    TokenExists,
+
+    #[error("Token denom was never created")]
+    TokenDoesntExist,
 }

--- a/packages/bindings-test/src/multitest.rs
+++ b/packages/bindings-test/src/multitest.rs
@@ -14,15 +14,21 @@ use cosmwasm_std::{
 use cw_multi_test::{
     App, AppResponse, BankKeeper, BankSudo, BasicAppBuilder, CosmosRouter, Module, WasmKeeper,
 };
+use cw_storage_plus::Map;
+
+use token_bindings::{
+    FullDenomResponse, Metadata, TokenFactoryMsg, TokenFactoryQuery, TokenMsg, TokenQuery,
+};
 
 use crate::error::ContractError;
-use token_bindings::{FullDenomResponse, TokenFactoryMsg, TokenFactoryQuery, TokenMsg, TokenQuery};
 
 pub struct TokenFactoryModule {}
 
 /// How many seconds per block
 /// (when we increment block.height, use this multiplier for block.time)
 pub const BLOCK_TIME: u64 = 5;
+
+const _METADATA: Map<&str, Metadata> = Map::new("metadata");
 
 impl TokenFactoryModule {
     fn build_denom(&self, creator: &Addr, subdenom: &str) -> Result<String, ContractError> {
@@ -95,17 +101,15 @@ impl Module for TokenFactoryModule {
                 denom: _,
                 amount: _,
                 burn_from_address: _,
-            } => Ok(AppResponse {
-                data: None,
-                events: vec![],
-            }),
+            } => todo!(),
             TokenMsg::ChangeAdmin {
-                denom: _denom,
-                new_admin_address: _new_admin_address,
-            } => Ok(AppResponse {
-                data: None,
-                events: vec![],
-            }),
+                denom: _,
+                new_admin_address: _,
+            } => todo!(),
+            TokenMsg::SetMetadata {
+                denom: _,
+                metadata: _,
+            } => todo!(),
         }
     }
 
@@ -143,6 +147,10 @@ impl Module for TokenFactoryModule {
                 let res = FullDenomResponse { denom };
                 Ok(to_binary(&res)?)
             }
+            TokenQuery::Metadata { denom: _ } => todo!(),
+            TokenQuery::Admin { denom: _ } => todo!(),
+            TokenQuery::DenomsByCreator { creator: _ } => todo!(),
+            TokenQuery::Params {} => todo!(),
         }
     }
 }

--- a/packages/bindings-test/src/multitest.rs
+++ b/packages/bindings-test/src/multitest.rs
@@ -17,7 +17,7 @@ use cw_multi_test::{
 use cw_storage_plus::Map;
 
 use token_bindings::{
-    AdminResponse, CreateDenomReponse, DenomsByCreatorResponse, FullDenomResponse, Metadata,
+    AdminResponse, CreateDenomResponse, DenomsByCreatorResponse, FullDenomResponse, Metadata,
     MetadataResponse, TokenFactoryMsg, TokenFactoryQuery, TokenMsg, TokenQuery,
 };
 
@@ -94,7 +94,7 @@ impl Module for TokenFactoryModule {
                 denoms.push(new_token_denom.clone());
                 DENOMS_BY_CREATOR.save(storage, &sender, &denoms)?;
 
-                let data = Some(CreateDenomReponse { new_token_denom }.encode()?);
+                let data = Some(CreateDenomResponse { new_token_denom }.encode()?);
                 Ok(AppResponse {
                     data,
                     events: vec![],
@@ -335,8 +335,7 @@ mod tests {
             mint_to_address: rcpt.to_string(),
         };
 
-        // simulate contract calling
-        // TODO: How is this not erroring, the token isn't created
+        // fails to mint token before creating it
         let err = app
             .execute(contract.clone(), msg.clone().into())
             .unwrap_err();

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "token-bindings"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Bindings for CustomMsg and CustomQuery for the Osmosis blockchain"

--- a/packages/bindings/examples/schema.rs
+++ b/packages/bindings/examples/schema.rs
@@ -3,7 +3,10 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
-use token_bindings::{FullDenomResponse, TokenFactoryMsg, TokenFactoryQuery};
+use token_bindings::{
+    AdminResponse, DenomsByCreatorResponse, FullDenomResponse, MetadataResponse, ParamsResponse,
+    TokenFactoryMsg, TokenFactoryQuery,
+};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -13,5 +16,9 @@ fn main() {
 
     export_schema(&schema_for!(TokenFactoryMsg), &out_dir);
     export_schema(&schema_for!(TokenFactoryQuery), &out_dir);
+    export_schema(&schema_for!(AdminResponse), &out_dir);
+    export_schema(&schema_for!(DenomsByCreatorResponse), &out_dir);
     export_schema(&schema_for!(FullDenomResponse), &out_dir);
+    export_schema(&schema_for!(MetadataResponse), &out_dir);
+    export_schema(&schema_for!(ParamsResponse), &out_dir);
 }

--- a/packages/bindings/examples/schema.rs
+++ b/packages/bindings/examples/schema.rs
@@ -3,7 +3,7 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
-use token_bindings::{TokenFactoryMsg, TokenFactoryQuery, FullDenomResponse};
+use token_bindings::{FullDenomResponse, TokenFactoryMsg, TokenFactoryQuery};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/packages/bindings/src/lib.rs
+++ b/packages/bindings/src/lib.rs
@@ -3,7 +3,7 @@ mod querier;
 mod query;
 mod types;
 
-pub use msg::{CreateDenomReponse, TokenFactoryMsg, TokenMsg};
+pub use msg::{CreateDenomResponse, TokenFactoryMsg, TokenMsg};
 pub use querier::TokenQuerier;
 pub use query::{
     AdminResponse, DenomsByCreatorResponse, FullDenomResponse, MetadataResponse, ParamsResponse,

--- a/packages/bindings/src/lib.rs
+++ b/packages/bindings/src/lib.rs
@@ -1,11 +1,15 @@
-mod metadata;
 mod msg;
 mod querier;
 mod query;
+mod types;
 
-pub use msg::{TokenFactoryMsg, TokenMsg};
+pub use msg::{CreateDenomReponse, TokenFactoryMsg, TokenMsg};
 pub use querier::TokenQuerier;
-pub use query::{FullDenomResponse, TokenFactoryQuery, TokenQuery};
+pub use query::{
+    AdminResponse, DenomsByCreatorResponse, FullDenomResponse, MetadataResponse, ParamsResponse,
+    TokenFactoryQuery, TokenQuery,
+};
+pub use types::{Metadata, Params};
 
 // This is a signal, such that any contract that imports these helpers will only run on
 // blockchains that support token_factory feature

--- a/packages/bindings/src/lib.rs
+++ b/packages/bindings/src/lib.rs
@@ -1,10 +1,11 @@
+mod metadata;
 mod msg;
 mod querier;
 mod query;
 
 pub use msg::{TokenFactoryMsg, TokenMsg};
 pub use querier::TokenQuerier;
-pub use query::{TokenFactoryQuery, FullDenomResponse, TokenQuery};
+pub use query::{FullDenomResponse, TokenFactoryQuery, TokenQuery};
 
 // This is a signal, such that any contract that imports these helpers will only run on
 // blockchains that support token_factory feature

--- a/packages/bindings/src/metadata.rs
+++ b/packages/bindings/src/metadata.rs
@@ -1,0 +1,33 @@
+use cosmwasm_schema::cw_serde;
+
+/// This maps to cosmos.bank.v1beta1.Metadata protobuf struct
+#[cw_serde]
+pub struct Metadata {
+    pub description: Option<String>,
+    /// denom_units represents the list of DenomUnit's for a given coin
+    pub denom_units: Vec<DenomUnit>,
+    /// base represents the base denom (should be the DenomUnit with exponent = 0).
+    pub base: Option<String>,
+    /// display indicates the suggested denom that should be displayed in clients.
+    pub display: Option<String>,
+    /// name defines the name of the token (eg: Cosmos Atom)
+    pub name: Option<String>,
+    /// symbol is the token symbol usually shown on exchanges (eg: ATOM). This can
+    /// be the same as the display.
+    pub symbol: Option<String>,
+}
+
+/// This maps to cosmos.bank.v1beta1.DenomUnit protobuf struct
+#[cw_serde]
+pub struct DenomUnit {
+    /// denom represents the string name of the given denom unit (e.g uatom).
+    pub denom: String,
+    /// exponent represents power of 10 exponent that one must
+    /// raise the base_denom to in order to equal the given DenomUnit's denom
+    /// 1 denom = 1^exponent base_denom
+    /// (e.g. with a base_denom of uatom, one can create a DenomUnit of 'atom' with
+    /// exponent = 6, thus: 1 atom = 10^6 uatom).
+    exponent: u32,
+    /// aliases is a list of string aliases for the given denom
+    aliases: Vec<String>,
+}

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -20,8 +20,12 @@ pub enum TokenMsg {
     /// The (creating contract address, subdenom) pair must be unique.
     /// The created denom's admin is the creating contract address,
     /// but this admin can be changed using the UpdateAdmin binding.
+    ///
+    /// If you set an initial metadata here, this is equivalent
+    /// to calling SetMetadata directly on the returned denom.
     CreateDenom {
         subdenom: String,
+        metadata: Option<Metadata>,
     },
     /// ChangeAdmin changes the admin for a factory denom.
     /// Can only be called by the current contract admin.

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -1,6 +1,6 @@
-use crate::metadata::Metadata;
+use crate::types::Metadata;
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{CosmosMsg, CustomMsg, Uint128};
+use cosmwasm_std::{Binary, CosmosMsg, CustomMsg, StdResult, Uint128};
 
 /// A top-level Custom message for the token factory.
 /// It is embedded like this to easily allow adding other variants that are custom
@@ -77,3 +77,115 @@ impl From<TokenMsg> for CosmosMsg<TokenFactoryMsg> {
 }
 
 impl CustomMsg for TokenFactoryMsg {}
+
+/// This is in the data field in the reply from a TokenMsg::CreateDenom SubMsg
+/// Custom code to parse from protobuf with minimal wasm bytecode bloat
+pub struct CreateDenomReponse {
+    pub new_token_denom: String,
+}
+
+impl CreateDenomReponse {
+    /// Call this to process data field from the SubMsg data field
+    pub fn from_reply_data(data: Binary) -> StdResult<Self> {
+        // Manual protobuf decoding
+        let mut data = Vec::from(data);
+        // Parse contract addr
+        let new_token_denom = copied_from_cw_utils::parse_protobuf_string(&mut data, 1)?;
+        Ok(CreateDenomReponse { new_token_denom })
+    }
+}
+
+// FIXME: just import cw_utils::parse_protobuf_string when it is exported
+mod copied_from_cw_utils {
+    use cosmwasm_std::{StdError, StdResult};
+
+    // Protobuf wire types (https://developers.google.com/protocol-buffers/docs/encoding)
+    const WIRE_TYPE_LENGTH_DELIMITED: u8 = 2;
+    // Up to 9 bytes of varints as a practical limit (https://github.com/multiformats/unsigned-varint#practical-maximum-of-9-bytes-for-security)
+    const VARINT_MAX_BYTES: usize = 9;
+
+    pub fn parse_protobuf_string(data: &mut Vec<u8>, field_number: u8) -> StdResult<String> {
+        let str_field = parse_protobuf_length_prefixed(data, field_number)?;
+        Ok(String::from_utf8(str_field)?)
+    }
+
+    /// Helper function to parse length-prefixed protobuf fields.
+    /// The remaining of the data is kept in the data parameter.
+    fn parse_protobuf_length_prefixed(data: &mut Vec<u8>, field_number: u8) -> StdResult<Vec<u8>> {
+        if data.is_empty() {
+            return Ok(vec![]);
+        };
+        let mut rest_1 = data.split_off(1);
+        let wire_type = data[0] & 0b11;
+        let field = data[0] >> 3;
+
+        if field != field_number {
+            return Err(StdError::parse_err(
+                "length_prefix_field",
+                format!(
+                    "failed to decode Protobuf message: invalid field #{} for field #{}",
+                    field, field_number
+                ),
+            ));
+        }
+        if wire_type != WIRE_TYPE_LENGTH_DELIMITED {
+            return Err(StdError::parse_err(
+                "length_prefix_field",
+                format!(
+                    "failed to decode Protobuf message: field #{}: invalid wire type {}",
+                    field_number, wire_type
+                ),
+            ));
+        }
+
+        let len = parse_protobuf_varint(&mut rest_1, field_number)?;
+        if rest_1.len() < len {
+            return Err(StdError::parse_err(
+                "length_prefix_field",
+                format!(
+                    "failed to decode Protobuf message: field #{}: message too short",
+                    field_number
+                ),
+            ));
+        }
+        *data = rest_1.split_off(len);
+
+        Ok(rest_1)
+    }
+
+    /// Base128 varint decoding.
+    /// The remaining of the data is kept in the data parameter.
+    fn parse_protobuf_varint(data: &mut Vec<u8>, field_number: u8) -> StdResult<usize> {
+        let data_len = data.len();
+        let mut len: u64 = 0;
+        let mut i = 0;
+        while i < VARINT_MAX_BYTES {
+            if data_len == i {
+                return Err(StdError::parse_err(
+                    "varint",
+                    format!(
+                        "failed to decode Protobuf message: field #{}: varint data too short",
+                        field_number
+                    ),
+                ));
+            }
+            len += ((data[i] & 0x7f) as u64) << (i * 7);
+            if data[i] & 0x80 == 0 {
+                break;
+            }
+            i += 1;
+        }
+        if i == VARINT_MAX_BYTES {
+            return Err(StdError::parse_err(
+                "varint",
+                format!(
+                    "failed to decode Protobuf message: field #{}: varint data too long",
+                    field_number
+                ),
+            ));
+        }
+        *data = data[i + 1..].to_owned();
+
+        Ok(len as usize) // Gently fall back to the arch's max addressable size
+    }
+}

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -96,6 +96,11 @@ impl CreateDenomReponse {
         let new_token_denom = copied_from_cw_utils::parse_protobuf_string(&mut data, 1)?;
         Ok(CreateDenomReponse { new_token_denom })
     }
+
+    pub fn encode(&self) -> StdResult<Binary> {
+        // TODO
+        Ok(b"".into())
+    }
 }
 
 // FIXME: just import cw_utils::parse_protobuf_string when it is exported

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -45,7 +45,10 @@ pub enum TokenMsg {
         amount: Uint128,
         burn_from_address: String,
     },
-    SetMetadata(Metadata),
+    SetMetadata {
+        denom: String,
+        metadata: Metadata,
+    },
 }
 
 impl TokenMsg {

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -1,3 +1,4 @@
+use crate::metadata::Metadata;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{CosmosMsg, CustomMsg, Uint128};
 
@@ -19,7 +20,9 @@ pub enum TokenMsg {
     /// The (creating contract address, subdenom) pair must be unique.
     /// The created denom's admin is the creating contract address,
     /// but this admin can be changed using the UpdateAdmin binding.
-    CreateDenom { subdenom: String },
+    CreateDenom {
+        subdenom: String,
+    },
     /// ChangeAdmin changes the admin for a factory denom.
     /// Can only be called by the current contract admin.
     /// If the NewAdminAddress is empty, the denom will have no admin.
@@ -42,7 +45,7 @@ pub enum TokenMsg {
         amount: Uint128,
         burn_from_address: String,
     },
-    // TODO: consider more meta-data extensions
+    SetMetadata(Metadata),
 }
 
 impl TokenMsg {

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -83,18 +83,18 @@ impl CustomMsg for TokenFactoryMsg {}
 
 /// This is in the data field in the reply from a TokenMsg::CreateDenom SubMsg
 /// Custom code to parse from protobuf with minimal wasm bytecode bloat
-pub struct CreateDenomReponse {
+pub struct CreateDenomResponse {
     pub new_token_denom: String,
 }
 
-impl CreateDenomReponse {
+impl CreateDenomResponse {
     /// Call this to process data field from the SubMsg data field
     pub fn from_reply_data(data: Binary) -> StdResult<Self> {
         // Manual protobuf decoding
         let mut data = Vec::from(data);
         // Parse contract addr
         let new_token_denom = copied_from_cw_utils::parse_protobuf_string(&mut data, 1)?;
-        Ok(CreateDenomReponse { new_token_denom })
+        Ok(CreateDenomResponse { new_token_denom })
     }
 
     pub fn encode(&self) -> StdResult<Binary> {

--- a/packages/bindings/src/querier.rs
+++ b/packages/bindings/src/querier.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{QuerierWrapper, StdResult};
 
-use crate::query::{TokenFactoryQuery, FullDenomResponse, TokenQuery};
+use crate::query::{FullDenomResponse, TokenFactoryQuery, TokenQuery};
 
 /// This is a helper wrapper to easily use our custom queries
 pub struct TokenQuerier<'a> {

--- a/packages/bindings/src/query.rs
+++ b/packages/bindings/src/query.rs
@@ -1,4 +1,4 @@
-use crate::metadata::Metadata;
+use crate::types::{Metadata, Params};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{CustomQuery, QueryRequest};
 
@@ -34,6 +34,9 @@ pub enum TokenQuery {
     /// (Admin may have changed)
     #[returns(DenomsByCreatorResponse)]
     DenomsByCreator { creator: String },
+    /// Returns configuration params for TokenFactory modules
+    #[returns(ParamsResponse)]
+    Params {},
 }
 
 impl CustomQuery for TokenFactoryQuery {}
@@ -63,4 +66,9 @@ pub struct AdminResponse {
 #[cw_serde]
 pub struct DenomsByCreatorResponse {
     pub denoms: Vec<String>,
+}
+
+#[cw_serde]
+pub struct ParamsResponse {
+    pub params: Params,
 }

--- a/packages/bindings/src/query.rs
+++ b/packages/bindings/src/query.rs
@@ -1,9 +1,10 @@
+use crate::metadata::Metadata;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{CustomQuery, QueryRequest};
 
 #[cw_serde]
 pub enum TokenFactoryQuery {
-    // TODO: test how this works with cw_serde
+    // Note: embded enums don't work with QueryResponses currently
     Token(TokenQuery),
 }
 
@@ -19,7 +20,20 @@ pub enum TokenQuery {
         creator_addr: String,
         subdenom: String,
     },
-    // TODO: more about metadata? owner?
+    /// Returns the metadata set for this denom, if present. May return None.
+    /// This will also return metadata for native tokens created outside
+    /// of the token factory (like staking tokens)
+    #[returns(MetadataResponse)]
+    Metadata { denom: String },
+    /// Returns info on admin of the denom, only if created/managed via token factory.
+    /// Errors if denom doesn't exist or was created by another module.
+    #[returns(AdminResponse)]
+    Admin { denom: String },
+    /// List all denoms that were created by the given creator.
+    /// This does not imply all tokens currently managed by the creator.
+    /// (Admin may have changed)
+    #[returns(DenomsByCreatorResponse)]
+    DenomsByCreator { creator: String },
 }
 
 impl CustomQuery for TokenFactoryQuery {}
@@ -33,4 +47,20 @@ impl From<TokenQuery> for QueryRequest<TokenFactoryQuery> {
 #[cw_serde]
 pub struct FullDenomResponse {
     pub denom: String,
+}
+
+#[cw_serde]
+pub struct MetadataResponse {
+    /// Empty if this was never set for the given denom
+    pub metadata: Option<Metadata>,
+}
+
+#[cw_serde]
+pub struct AdminResponse {
+    pub admin: String,
+}
+
+#[cw_serde]
+pub struct DenomsByCreatorResponse {
+    pub denoms: Vec<String>,
 }

--- a/packages/bindings/src/types.rs
+++ b/packages/bindings/src/types.rs
@@ -1,4 +1,5 @@
 use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Coin;
 
 /// This maps to cosmos.bank.v1beta1.Metadata protobuf struct
 #[cw_serde]
@@ -30,4 +31,11 @@ pub struct DenomUnit {
     exponent: u32,
     /// aliases is a list of string aliases for the given denom
     aliases: Vec<String>,
+}
+
+/// This maps to osmosis.tokenfactory.v1beta1.Params protobuf struct
+#[cw_serde]
+pub struct Params {
+    /// TODO: verify semantics - does it charge all of these or one of these?
+    pub denom_creation_fee: Vec<Coin>,
 }


### PR DESCRIPTION
Closes #1 

Cover all existing protocols msg and queries exposed as of osmosis v12 implementation.

This is missing a few tests on the multitest implementation, as well as support for the params, and proper mock responses for CreateDenomMsg