### PR TITLE
Making DenomUnit public so all Metadata fields can be set

### DIFF
--- a/contracts/tokenfactory/src/msg.rs
+++ b/contracts/tokenfactory/src/msg.rs
@@ -1,5 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
+use token_bindings::Metadata;
 
 #[cw_serde]
 pub struct InstantiateMsg {}
@@ -8,6 +9,7 @@ pub struct InstantiateMsg {}
 pub enum ExecuteMsg {
     CreateDenom {
         subdenom: String,
+        metadata: Option<Metadata>,
     },
     ChangeAdmin {
         denom: String,

--- a/packages/bindings/src/lib.rs
+++ b/packages/bindings/src/lib.rs
@@ -9,7 +9,7 @@ pub use query::{
     AdminResponse, DenomsByCreatorResponse, FullDenomResponse, MetadataResponse, ParamsResponse,
     TokenFactoryQuery, TokenQuery,
 };
-pub use types::{Metadata, Params};
+pub use types::{DenomUnit, Metadata, Params};
 
 // This is a signal, such that any contract that imports these helpers will only run on
 // blockchains that support token_factory feature

--- a/packages/bindings/src/types.rs
+++ b/packages/bindings/src/types.rs
@@ -28,9 +28,9 @@ pub struct DenomUnit {
     /// 1 denom = 1^exponent base_denom
     /// (e.g. with a base_denom of uatom, one can create a DenomUnit of 'atom' with
     /// exponent = 6, thus: 1 atom = 10^6 uatom).
-    exponent: u32,
+    pub exponent: u32,
     /// aliases is a list of string aliases for the given denom
-    aliases: Vec<String>,
+    pub aliases: Vec<String>,
 }
 
 /// This maps to osmosis.tokenfactory.v1beta1.Params protobuf struct


### PR DESCRIPTION
This PR exposes the `DenomUnit` struct so that `Metadata` can be created using all its fields when creating a denom. 